### PR TITLE
Build sasquatch packages for ARM architecture.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,14 +17,42 @@ on:
 
 # A workflow run is made up of one or more jobs that can run sequentially or in parallel
 jobs:
-  build:
+  build_amd64:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
-      - name: Build Debian package
-        uses: dawidd6/action-debian-package@v1.4.0
+      - name: Build Debian package (AMD64)
+        uses: dawidd6/action-debian-package@v1.4.4
         with:
           os_distribution: bullseye
+          cpu_architecture: amd64
+      - name: Upload DEB artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          path: ${{ github.workspace }}/*.deb
+  build_arm64:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build Debian package (AARCH64)
+        uses: dawidd6/action-debian-package@v1.4.4
+        with:
+          os_distribution: bullseye
+          cpu_architecture: arm64
+      - name: Upload DEB artifacts
+        uses: actions/upload-artifact@v2
+        with:
+          path: ${{ github.workspace }}/*.deb
+          if-no-files-found: error
+  build_arm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build Debian package (ARM32)
+        uses: dawidd6/action-debian-package@v1.4.4
+        with:
+          os_distribution: bullseye
+          cpu_architecture: arm
       - name: Upload DEB artifacts
         uses: actions/upload-artifact@v2
         with:


### PR DESCRIPTION
With the availability of [pyperscan](https://github.com/vlaci/pyperscan/), we can now build unblob for ARM architecture (see https://github.com/onekey-sec/unblob/pull/475).

To be complete, we need to release sasquatch packages for ARM too. Otherwise building docker images for ARM fails:

```
docker buildx build --platform linux/arm64 -t onekey/unblob:arm64 .
[+] Building 126.4s (11/14)                                                                                                                                                                                        
 => [internal] load build definition from Dockerfile                                                                                                                                                          0.0s
 => => transferring dockerfile: 32B                                                                                                                                                                           0.0s
 => [internal] load .dockerignore                                                                                                                                                                             0.0s
 => => transferring context: 34B                                                                                                                                                                              0.0s
 => [internal] load metadata for docker.io/library/python:3.8-slim                                                                                                                                            0.0s
 => [internal] load build context                                                                                                                                                                             0.2s
 => => transferring context: 100B                                                                                                                                                                             0.2s
 => [ 1/10] FROM docker.io/library/python:3.8-slim                                                                                                                                                            0.0s
 => CACHED [ 2/10] RUN mkdir -p /data/input /data/output                                                                                                                                                      0.0s
 => CACHED [ 3/10] RUN useradd -m unblob                                                                                                                                                                      0.0s
 => CACHED [ 4/10] RUN chown -R unblob /data                                                                                                                                                                  0.0s
 => CACHED [ 5/10] WORKDIR /data/output                                                                                                                                                                       0.0s
 => [ 6/10] RUN apt-get update && apt-get install --no-install-recommends -y     curl     e2fsprogs     gcc     git     img2simg     liblzo2-dev     lz4     lziprecover     lzop     p7zip-full     unar   113.6s
 => ERROR [ 7/10] RUN curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v1.0/sasquatch_1.0_amd64.deb     && dpkg -i sasquatch_1.0_amd64.deb     && rm   12.6s
------                                                                                                                                                                                                             
 > [ 7/10] RUN curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v1.0/sasquatch_1.0_amd64.deb     && dpkg -i sasquatch_1.0_amd64.deb     && rm -f sasquatch_1.0_amd64.deb:                                                                                                                                                                                                       
#0 0.665   % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current                                                                                                                           
#0 0.667                                  Dload  Upload   Total   Spent    Left  Speed                                                                                                                             
  0     0    0     0    0     0      0      0 --:--:--  0:00:05 --:--:--     0                                                                                                                                     
100  181k  100  181k    0     0  16048      0  0:00:11  0:00:11 --:--:-- 41554
#0 12.52 dpkg: error processing archive sasquatch_1.0_amd64.deb (--install):
#0 12.52  package architecture (amd64) does not match system (arm64)
#0 12.57 Errors were encountered while processing:
#0 12.57  sasquatch_1.0_amd64.deb
------
ERROR: failed to solve: executor failed running [/bin/sh -c curl -L -o sasquatch_1.0_amd64.deb https://github.com/onekey-sec/sasquatch/releases/download/sasquatch-v1.0/sasquatch_1.0_amd64.deb     && dpkg -i sasquatch_1.0_amd64.deb     && rm -f sasquatch_1.0_amd64.deb]: exit code: 1
```

This merge request modifies our Github workflow in order to build Debian packages for AMD64, AARCH64, and ARM32,

The workflow in action: https://github.com/onekey-sec/sasquatch/actions/runs/3603518758