### PR TITLE
add proper support for squashfs v2

### DIFF
--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -2290,27 +2290,20 @@ int read_super(char *source)
 	 */
 	int res = read_super_4(&s_ops);
 
-	if(res != -1)
-		return res;
-	else {
-		res = read_super_3(source, &s_ops, &sBlk_3);
+    if(res == -1) {
+        res = read_super_3(source, &s_ops, &sBlk_3);
 
-		if(res != -1)
-			return res;
-		else  {
-			res = read_super_2(&s_ops, &sBlk_3);
+        if(res != -1 && sBlk_3.s_major == 2){
+            res = read_super_2(&s_ops, &sBlk_3);
+        }
+        else if (res != -1 && sBlk_3.s_major == 1){
+            res = read_super_1(&s_ops, &sBlk_3);
+        }
+    }
 
-			if(res != -1)
-				return res;
-
-			else {
-				res = read_super_1(&s_ops, &sBlk_3);
-
-				if(res != -1)
-					return res;
-			}
-		}
-	}
+    if(res != -1) {
+        return res;
+    }
 
 	return FALSE;
 }


### PR DESCRIPTION
Since squashfs version 2 and 1 have a similar header structure than version 3, the call to read_super_3 always returns 1, which means the first if condition after the read_super_3 is always taken and version 2 and 1 never properly parsed.

This commit fix this condition and select the parsing function to call based on identified major version.

Probably an upstream bug in squashfs-tools by the way.