### PR TITLE
fix: remove regression introduced by b269533.

### DIFF
--- a/squashfs-tools/compressor.c
+++ b/squashfs-tools/compressor.c
@@ -78,6 +78,7 @@ extern struct compressor lzma_alt_comp_ops;
 extern struct compressor lzma_wrt_comp_ops;
 extern struct compressor lzma_adaptive_comp_ops;
 
+extern int ignore_errors;
 
 static struct compressor unknown_comp_ops = {
 	0, "unknown"
@@ -173,10 +174,15 @@ int compressor_uncompress(struct compressor *comp, void *dest, void *src, int si
 {
     int i = 0, retval = -1, default_compressor_id = -1;
 
+    int global_ignore_errors = ignore_errors;
+    ignore_errors = 1;
+
     if(detected_compressor_index)
     {
         retval = compressor[detected_compressor_index]->uncompress(dest, src, size, block_size, error);
     }
+
+    ignore_errors = global_ignore_errors;
 
     if(retval < 1 && comp->uncompress)
     {


### PR DESCRIPTION
When the maintainers of squashfs-tools introduced non-fatal error hardening, they also introduced a regression for sasquatch.

This was introduced by commit b26953313f99bff53f8d4f029ab8615d172791b7, where "If the writer thread fails to write a block to the output filesystem, treat this as a fatal error.".

The problem is that these non-fatal error will happen when sasquatch enumerate through the different compression implementation, and especially with LZMA adaptive it appears.

The fix is to comment the call to EXIT_UNSQUASH_LIKELY for that very specific case. The rest can stay.

Fixes #14 

---

For those of you who are curious, I did this by running `git bisect` on the original squashfs-tools repo with this ugly script:

```
#!/bin/sh

# delete garbage
find -name '*rej' -exec rm {} \;
find -name '*orig' -exec rm {} \;
rm -f squashfs-tools/LICENSE
rm -rf squashfs-tools/LZMA/
rm -f squashfs-tools/README.md

# hard reset to be sure
git reset --hard HEAD

# apply patch
patch -p0 < /tmp/patch0.txt

# compile and run
cd squashfs-tools
make clean
make -j4
./sasquatch -f -d /tmp/out /tmp/sample.sqsh4 2>&1| grep 'Detected lzma-adaptive compression'
EXIT_CODE=$?
# cleanup our mess
make clean
cd ..
find -name '*rej' -exec rm {} \;
find -name '*orig' -exec rm {} \;
rm -f squashfs-tools/LICENSE
rm -rf squashfs-tools/LZMA/
rm -f squashfs-tools/README.md
return $EXIT_CODE
```

 I had to adapt the patch file 3 times when stumbling on bad commits (according to git bisect), that were bad because the patch was no longer valid,

Fun times !