### PR TITLE
Fix nix build on recent nixpkgs

### DIFF
--- a/.github/workflows/build-nix.yml
+++ b/.github/workflows/build-nix.yml
@@ -27,6 +27,7 @@ jobs:
       - name: Setup emulation
         if: ${{ matrix.arch == 'aarch64-linux' }}
         run: |
+          sudo apt update
           sudo apt install -q -y qemu-system-aarch64 qemu-efi binfmt-support qemu-user-static
           mkdir -p ~/.config/nix
           echo "system-features = aarch64-linux arm-linux" | sudo tee -a /etc/nix/nix.conf

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "nixpkgs": {
       "locked": {
-        "lastModified": 1676928847,
-        "narHash": "sha256-FIqk+DHRICsWozlOdRxOXO/g9hCqjPYpmr8wQGrpUCA=",
+        "lastModified": 1683267615,
+        "narHash": "sha256-A/zAy9YauwdPut90h6cYC1zgP/WmuW9zmJ+K/c5i6uc=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "5ab8b5ae26e6a4b781bdebdfd131c054f0b96e70",
+        "rev": "0b6445b611472740f02eae9015150c07c5373340",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -23,12 +23,22 @@
     in
     {
       overlays.default = final: prev: {
-        sasquatch-le = final.squashfsTools.overrideAttrs (_: {
-          pname = "sasquatch-le";
-          inherit version;
+        sasquatch-le =
+          let
+            inherit (final) lib;
+          in
+          final.squashfsTools.overrideAttrs (_: {
+            pname = "sasquatch-le";
+            inherit version;
 
-          src = ./.;
-        });
+            patches = lib.optionals final.stdenv.isDarwin
+              (final.fetchpatch {
+                url = "https://raw.githubusercontent.com/NixOS/nixpkgs/ed81545df5083a95ddcfbff0c029774ecb0326bd/pkgs/tools/filesystems/squashfs/darwin.patch";
+                hash = "sha256-bSh9srb5WXD4KNCxALywdNMZcYQLFnrAzkTMRBnhXD8=";
+              });
+
+            src = ./.;
+          });
 
         sasquatch-be = final.sasquatch-le.overrideAttrs (super: {
           pname = "sasquatch-be";


### PR DESCRIPTION
In the meantime, the situation changed: nixpkgs dropped the patch[^2] needed for darwin support of squashfsTools 4.5.1, as it is not needed for 4.6.1. As we are using our own sources, we need to fetch it ourselves.
 
---
~The `4k-align.patch`[^1] coming from upstream nixpkgs fails to apply now, because it is adjusted for squashFsTools 4.6 
This is not needed for us, so we filter it out~

[^1]: https://github.com/NixOS/nixpkgs/blob/master/pkgs/tools/filesystems/squashfs/4k-align.patch
[^2]: https://github.com/NixOS/nixpkgs/commit/d5904d7e6b57d82212be4db9745633fd93925f37