### PR TITLE
fix: disable sanity check to handle malformed filesystem from D-Link.

### DIFF
--- a/squashfs-tools/unsquash-123.c
+++ b/squashfs-tools/unsquash-123.c
@@ -40,7 +40,7 @@ int read_ids(int ids, long long start, long long end, unsigned int **id_table)
 	 * The size of the index table (length bytes) should match the
 	 * table start and end points
 	 */
-	if(length != (end - start)) {
+	if(length > (end - start)) {
 		ERROR("read_ids: Bad inode count in super block\n");
 		return FALSE;
 	}


### PR DESCRIPTION
squashfs-tools maintainer introduced a sanity check with commits [3954bbb8e44f54a7081d84ddb968c2c2f210ad09](https://github.com/plougher/squashfs-tools/commit/3954bbb8e44f54a7081d84ddb968c2c2f210ad09) and [734a85f5f117c2d92829a1874b952efa6c1d4f4d](https://github.com/plougher/squashfs-tools/commit/734a85f5f117c2d92829a1874b952efa6c1d4f4d).

These checks means sasquatch can't extract squashfs v2 filesystems from D-Link.

Reproduction samples can be found here:
- http://legacyfiles.us.dlink.com/DIR-600L/REVA/FIRMWARE/
- http://legacyfiles.us.dlink.com/DIR-515/REVA/FIRMWARE/

I'm still not sure if the error lies on D-Link for building malformed images or squashfs-tools for confusing squashfs v2 and v3 super block content. At this point I don't care and chose to comment the sanity check. I don't see any side effects in terms of memory access or usage.

Reported by @m-1-k-3