### PR TITLE
Unsquashfs: symlinks should not trigger directory loop code

### DIFF
--- a/squashfs-tools/unsquash-3.c
+++ b/squashfs-tools/unsquash-3.c
@@ -408,11 +408,6 @@ static struct dir *squashfs_opendir(unsigned int block_start, unsigned int offse
 
 	*i = read_inode(block_start, offset);
 
-	if(inumber_lookup((*i)->inode_number)) {
-		ERROR("File System corrupted: directory loop detected\n");
-		return NULL;
-	}
-
 	dir = malloc(sizeof(struct dir));
 	if(dir == NULL)
 		MEM_ERROR();

--- a/squashfs-tools/unsquash-4.c
+++ b/squashfs-tools/unsquash-4.c
@@ -360,11 +360,6 @@ static struct dir *squashfs_opendir(unsigned int block_start, unsigned int offse
 
 	*i = read_inode(block_start, offset);
 
-	if(inumber_lookup((*i)->inode_number)) {
-		ERROR("File System corrupted: directory loop detected\n");
-		return NULL;
-	}
-
 	dir = malloc(sizeof(struct dir));
 	if(dir == NULL)
 		MEM_ERROR();

--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -2024,6 +2024,11 @@ int pre_scan(char *parent_name, unsigned int start_block, unsigned int offset,
 	if(dir == NULL)
 		return FALSE;
 
+	if(inumber_lookup(i->inode_number)) {
+		ERROR("File System corrupted: directory loop detected\n");
+		return FALSE;
+	}
+
 	while(squashfs_readdir(dir, &name, &start_block, &offset, &type)) {
 		struct inode *i;
 		char *pathname;
@@ -2086,6 +2091,11 @@ int dir_scan(char *parent_name, unsigned int start_block, unsigned int offset,
 	if(dir == NULL) {
 		EXIT_UNSQUASH_IGNORE("dir_scan: failed to read directory %s\n",
 			parent_name);
+		return FALSE;
+	}
+
+	if(inumber_lookup(i->inode_number)) {
+		ERROR("File System corrupted: directory loop detected\n");
 		return FALSE;
 	}
 
@@ -3140,7 +3150,6 @@ struct pathname *resolve_symlinks(int argc, char *argv[])
 			SQUASHFS_INODE_BLK(sBlk.s.root_inode),
 			SQUASHFS_INODE_OFFSET(sBlk.s.root_inode),
 			1, 0, stack);
-		free_inumber_table();
 
 		if(!found) {
 			if(missing_symlinks)
@@ -3459,7 +3468,6 @@ int cat_path(int argc, char *argv[])
 			failed = TRUE;
 
 		free_stack(stack);
-		free_inumber_table();
 	}
 
 	queue_put(to_writer, NULL);
@@ -3581,6 +3589,11 @@ int pseudo_scan1(char *parent_name, unsigned int start_block, unsigned int offse
 		return FALSE;
 	}
 
+	if(inumber_lookup(i->inode_number)) {
+		ERROR("File System corrupted: directory loop detected\n");
+		return FALSE;
+	}
+
 	pseudo_print(parent_name, i, NULL, 0);
 
 	while(squashfs_readdir(dir, &name, &start_block, &offset, &type)) {
@@ -3655,6 +3668,11 @@ int pseudo_scan2(char *parent_name, unsigned int start_block, unsigned int offse
 
 	if(dir == NULL) {
 		ERROR("pseudo_scan2: failed to read directory %s\n", parent_name);
+		return FALSE;
+	}
+
+	if(inumber_lookup(i->inode_number)) {
+		ERROR("File System corrupted: directory loop detected\n");
 		return FALSE;
 	}
 


### PR DESCRIPTION
Following a symlink in Sqfscat or where -follow-symlinks option is given with Unsquashfs, will trigger the corrupted filesystem loop detection code, as it tries to reopen the directory containing the symlink.

Fixes https://github.com/plougher/squashfs-tools/issues/214