### PR TITLE
chore(ci): pin arm and aarch64 release to ubuntu-22.04 runners

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
         with:
           files: ${{ github.workspace }}/*.deb
   build_arm64:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Build Debian package (AARCH64)
@@ -33,7 +33,7 @@ jobs:
         with:
           files: ${{ github.workspace }}/*.deb
   build_arm:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v4
       - name: Build Debian package (ARM32)


### PR DESCRIPTION
dawidd6/action-debian-package@v1.6.0 is not compatible with ubuntu-latest (24.04) when asked to build ARM or AARCH64 deb packages.