### PR TITLE
unsquashfs: fix prototypes for C23

### DIFF
--- a/squashfs-tools/unsquashfs.c
+++ b/squashfs-tools/unsquashfs.c
@@ -146,7 +146,7 @@ void progress_bar(long long current, long long max, int columns);
 
 #define MAX_LINE 16384
 
-void sigwinch_handler()
+void sigwinch_handler(int _signal)
 {
 	struct winsize winsize;
 
@@ -160,7 +160,7 @@ void sigwinch_handler()
 }
 
 
-void sigalrm_handler()
+void sigalrm_handler(int _signal)
 {
 	rotate = (rotate + 1) % 4;
 }


### PR DESCRIPTION
As of C23, functions with no arguments are interpreted as taking no arguments rather than an ambiguous parameter list. Since C23 is the default with GCC 15, this causes build failures. We add `int` parameters to the signal handlers to avoid this.