### PR TITLE
fix: remove unnecessary magic checks

### DIFF
--- a/squashfs-tools/unsquash-2.c
+++ b/squashfs-tools/unsquash-2.c
@@ -590,8 +590,7 @@ int read_super_2(squashfs_operations **s_ops, void *s)
 {
 	 squashfs_super_block_3 *sBlk_3 = s;
 
-	if(sBlk_3->s_magic != SQUASHFS_MAGIC || sBlk_3->s_major != 2 ||
-							sBlk_3->s_minor > 1)
+	if(sBlk_3->s_major != 2 || sBlk_3->s_minor > 1)
 		return -1;
 
 	sBlk.s.s_magic = sBlk_3->s_magic;

--- a/squashfs-tools/unsquash-4.c
+++ b/squashfs-tools/unsquash-4.c
@@ -696,8 +696,7 @@ int read_super_4(squashfs_operations **s_ops)
 
 	SQUASHFS_INSWAP_SUPER_BLOCK(&sBlk_4);
 
-	if(sBlk_4.s_magic == SQUASHFS_MAGIC && sBlk_4.s_major == 4 &&
-			sBlk_4.s_minor == 0) {
+	if(sBlk_4.s_major == 4 && sBlk_4.s_minor == 0) {
 
 		// CJH: Update super struct with override values
         if(override.s_major)


### PR DESCRIPTION
Remove unnecessary magic checks so that squashfs variants of v2 and v4 with non-standard magic (e.g. sqlz or shsq) may be unpacked.

Should fix #19 

needed for https://github.com/onekey-sec/unblob/pull/1352 and apparently also https://github.com/onekey-sec/unblob/pull/639