### PR TITLE
feat: add support for v2 LZMA variant

### DIFF
--- a/squashfs-tools/squashfs_compat.h
+++ b/squashfs-tools/squashfs_compat.h
@@ -832,3 +832,9 @@ typedef struct squashfs_fragment_entry_2 squashfs_fragment_entry_2;
 }
 #define SQUASHFS_MEMSET(s, d, n)	memset(s, 0, n);
 #endif
+
+/*
+ * Minor version 76 ('L') indicates a variant of v2 from AVM/Freetz that uses
+ * LZMA file compression instead of gzip.
+ */
+#define SQUASHFS_MINOR_LZMA 76

--- a/squashfs-tools/unsquash-2.c
+++ b/squashfs-tools/unsquash-2.c
@@ -590,7 +590,7 @@ int read_super_2(squashfs_operations **s_ops, void *s)
 {
 	 squashfs_super_block_3 *sBlk_3 = s;
 
-	if(sBlk_3->s_major != 2 || sBlk_3->s_minor > 1)
+	if(sBlk_3->s_major != 2 || (sBlk_3->s_minor > 1 && sBlk_3->s_minor != SQUASHFS_MINOR_LZMA))
 		return -1;
 
 	sBlk.s.s_magic = sBlk_3->s_magic;
@@ -616,10 +616,14 @@ int read_super_2(squashfs_operations **s_ops, void *s)
 
 	*s_ops = &ops;
 
-	/*
-	 * 2.x filesystems use gzip compression.
+    /*
+	 * 2.x filesystems use gzip compression, unless s_minor == 76 ('L')
+	 * which indicates a AVM/Freetz variant with LZMA compression.
 	 */
-	comp = lookup_compressor("gzip");
+	if(sBlk_3->s_minor == SQUASHFS_MINOR_LZMA)
+		comp = lookup_compressor("lzma");
+	else
+		comp = lookup_compressor("gzip");
 
 	if(sBlk_3->s_minor == 0)
 		needs_sorting = TRUE;


### PR DESCRIPTION
Certain older AVM FRITZ!Box devices (e.g. FRITZ!Box 7170, 7270 and 7390) use a variant of the regular SquashFS v2 filesystem with LZMA compression (v2 regularly only supports gzip). This is indicated by a minor version of 76 ('L').

See also: https://github.com/Freetz/freetz/blob/master/tools/make/squashfs2-host/patches/300-lzma.patch 

Such a filesystem can be created with `mksquashfs2-lzma` which is part of the "Freetz(-NG) tools" and can be downloaded from https://github.com/Freetz-NG/dl-mirror/releases

This should also work with unblob without further changes (apart from updating the sasquatch version).